### PR TITLE
Use shallow clones for speed.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,10 +56,10 @@ cd ~/dev
 export CMAKE_PREFIX_PATH=`pwd`
 
 echo Getting HHVM source-code...
-git clone git://github.com/facebook/hhvm.git
+git clone git://github.com/facebook/hhvm.git --depth=1
 
 echo Building libCurl...
-git clone git://github.com/bagder/curl.git
+git clone git://github.com/bagder/curl.git --depth=1
 cd curl
 ./buildconf
 ./configure --prefix=$CMAKE_PREFIX_PATH


### PR DESCRIPTION
Suggest using shallow git clones as they are much faster on large repos with have had lots of commits (HHVM repo has over 10,000 commits). I don't believe the limitations imposed by shallow clones should be an issue here as we only clone the HHVM & cURL source in order to make builds, not to commit & push.
